### PR TITLE
allow-page-scrolling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Jetbrains webstorm
+.idea
+
 # Logs
 logs
 *.log

--- a/src/PinchView.js
+++ b/src/PinchView.js
@@ -82,6 +82,8 @@ PinchView.propTypes = {
   containerRatio: PropTypes.number,
   maxScale: PropTypes.number,
   children: PropTypes.element,
+  containerClassName: PropTypes.string,
+  holderClassName: PropTypes.string,
   backgroundColor: PropTypes.string,
   debug: PropTypes.bool
 }

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -20,6 +20,10 @@ function hasTwoTouchPoints (event) {
   }
 }
 
+function isZoomed (scale) {
+  return scale > 1
+}
+
 function between (min, max, val) {
   return Math.min(max, Math.max(min, val))
 }
@@ -85,7 +89,14 @@ class ReactPinchZoomPan extends Component {
     }
 
     const pinch = touchStart
-    .tap(eventPreventDefault)
+    .tap((event) => {
+      const {scale} = this.state.obj
+
+      // allow page scrolling - ignore events unless they are beginning pinch or have previously pinch zoomed
+      if (hasTwoTouchPoints(event) || isZoomed(scale)) {
+        eventPreventDefault(event)
+      }
+    })
     .flatMap((md) => {
       const startPoint = normalizeTouch(md)
       const {size} = this.state


### PR DESCRIPTION
Since touch-pan is not required when the images scale is 1, allow touch events to scroll the page while not zoomed. After a user pinch zooms the images, preventDefault is called and allows the zoomed image to then be touch-panned.