### PR TITLE
Typo in dependencies package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "lodash.throttle": "^4.0.1",
-    "prop-type": "0.0.1",
+    "prop-types": "^15.5.4",
     "react-prefixr": "^0.1.0",
     "rxjs": "^5.4.0"
   },


### PR DESCRIPTION
Seems like there was a typo during `prop-types` package installation
You try to import `prop-types` package in source files, but there's only `prop-type` package available in dependencies