### PR TITLE
Added ability to zoom in on specific coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ The component exposes a prop to set the `initialScale`. This can be used to disp
   }} />
 </PinchView>
 ```
+### Usage initial center
+
+The component lets you set `initialCenter`. The value must be an object with ```x``` and ```y``` like so: ```{x: -100, y: 50}```. Use it if you want to zoom in on a certain point:
+
+```
+<PinchView debug backgroundColor='#ddd' initialCenter={{x: -100, y: 50}} initalScale={2} maxScale={4} containerRatio={100}>
+  <img src={'http://lorempixel.com/400/600/nature/'} style={{
+    margin: 'auto',
+    width: 'auto',
+    height: '100%'
+  }} />
+</PinchView>
+```
 
 ## Discussion
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ The component lets you set `initialCenter`. The value must be an object with ```
   }} />
 </PinchView>
 ```
+### Usage zoomToDoubleClick
+
+You can zoom to a specific location on double-clicks. The value is ```true/false```, default is ```false```. Use it to enable automatic zooming to ```maxScale```. There is an example in the demo under the 'Double click' tab.
+
+```
+<PinchView debug zoomToDoubleClick backgroundColor='#ddd' initalScale={1} maxScale={5} containerRatio={100}>
+  <img src={'http://lorempixel.com/400/600/nature/'} style={{
+    margin: 'auto',
+    width: 'auto',
+    height: '100%'
+  }} />
+</PinchView>
+```
 
 ## Discussion
 

--- a/demo/App.js
+++ b/demo/App.js
@@ -48,6 +48,19 @@ const tabs = [{
     width: '100%',
     height: 'auto'
   }
+}, {
+  id: 'tab-4',
+  image: imageHorizontal2,
+  containerRatio: ((400 / 600) * 100),
+  maxScale: 5,
+  initialScale: 3,
+  label: 'Double-click',
+  text: 'This allows you to zoom to a double-click location',
+  styles: {
+    margin: 'auto',
+    width: '100%',
+    height: 'auto'
+  }
 }]
 
 export default class App extends Component {
@@ -55,7 +68,7 @@ export default class App extends Component {
     super(props)
     this.state = {
       // selectedTab: tabs[0].id,
-      selectedTab: tabs[3].id,
+      selectedTab: tabs[4].id,
       zoomed: false,
       initialCenter: {x: 0, y: 50}
     }
@@ -64,16 +77,10 @@ export default class App extends Component {
     this.setState({selectedTab})
   }
   onDblClick = (e) => {
-    e.preventDefault()
+    // e.preventDefault()
     // if (this.state.selectedTab === 'tab-3') {
     //   this.setState({ zoomed: !this.state.zoomed })
     // }
-    const { clientX: x, clientY: y } = e
-    console.log(`App.js/onDblClick() x: ${x}, y: ${y}`)
-    this.setState({initialCenter: {x, y}})
-
-    console.log(this.div.getBoundingClientRect())
-    this.div.id='foobar'
   }
   render () {
     const {selectedTab, zoomed, initialCenter} = this.state

--- a/demo/App.js
+++ b/demo/App.js
@@ -50,7 +50,7 @@ const tabs = [{
   }
 }, {
   id: 'tab-4',
-  image: imageHorizontal2,
+  image: imageHorizontal,
   containerRatio: ((400 / 600) * 100),
   maxScale: 5,
   initialScale: 1,

--- a/demo/App.js
+++ b/demo/App.js
@@ -67,10 +67,8 @@ export default class App extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      // selectedTab: tabs[0].id,
-      selectedTab: tabs[4].id,
-      zoomed: false,
-      initialCenter: {x: 0, y: 0}
+      selectedTab: tabs[0].id,
+      zoomed: false
     }
   }
   onChangeTab = (selectedTab) => {
@@ -83,7 +81,7 @@ export default class App extends Component {
     }
   }
   render () {
-    const {selectedTab, zoomed, initialCenter} = this.state
+    const {selectedTab, zoomed} = this.state
     const selectedTabContent = tabs.find(({id}) => id === selectedTab)
     const initialScale = selectedTabContent.initialScale * (zoomed ? 1.5 : 1)
     return (
@@ -107,7 +105,7 @@ export default class App extends Component {
               {tabs.map((tab, i) => <TabButton key={i} {...tab} onClick={this.onChangeTab} className={selectedTabContent && tab.id === selectedTabContent.id ? 'is-active' : ''} />)}
             </ul>
           </div>
-          {selectedTabContent && this.renderTabContent({...selectedTabContent, initialScale, initialCenter})}
+          {selectedTabContent && this.renderTabContent({...selectedTabContent, initialScale})}
         </div>
       </div>
     )
@@ -123,15 +121,15 @@ export default class App extends Component {
       </div>
     )
   }
-  renderTabContent ({maxScale, containerRatio, image, initialScale, initialCenter, text, styles}) {
+  renderTabContent ({maxScale, containerRatio, image, initialScale, text, styles}) {
     if (!image) {
       return this.renderUsage()
     }
     return (
       <div className='content'>
         <p>{text}</p>
-        <div className='pinch-wrapper' ref={ref=>this.div=ref}>
-          <PinchView debug backgroundColor='#ddd' initialCenter={initialCenter} maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
+        <div className='pinch-wrapper' ref={ref => { this.div = ref }}>
+          <PinchView debug backgroundColor='#ddd' maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
             <img src={image} style={styles} onDoubleClick={this.onDblClick} />
           </PinchView>
         </div>

--- a/demo/App.js
+++ b/demo/App.js
@@ -71,6 +71,9 @@ export default class App extends Component {
     const { clientX: x, clientY: y } = e
     console.log(`App.js/onDblClick() x: ${x}, y: ${y}`)
     this.setState({initialCenter: {x, y}})
+
+    console.log(this.div.getBoundingClientRect())
+    this.div.id='foobar'
   }
   render () {
     const {selectedTab, zoomed, initialCenter} = this.state
@@ -120,7 +123,7 @@ export default class App extends Component {
     return (
       <div className='content'>
         <p>{text}</p>
-        <div className='pinch-wrapper'>
+        <div className='pinch-wrapper' ref={ref=>this.div=ref}>
           <PinchView debug backgroundColor='#ddd' initialCenter={initialCenter} maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
             <img src={image} style={styles} onDoubleClick={this.onDblClick} />
           </PinchView>

--- a/demo/App.js
+++ b/demo/App.js
@@ -56,7 +56,8 @@ export default class App extends Component {
     this.state = {
       // selectedTab: tabs[0].id,
       selectedTab: tabs[3].id,
-      zoomed: false
+      zoomed: false,
+      initialCenter: {x: 0, y: 50}
     }
   }
   onChangeTab = (selectedTab) => {
@@ -64,12 +65,15 @@ export default class App extends Component {
   }
   onDblClick = (e) => {
     e.preventDefault()
-    if (this.state.selectedTab === 'tab-3') {
-      this.setState({ zoomed: !this.state.zoomed })
-    }
+    // if (this.state.selectedTab === 'tab-3') {
+    //   this.setState({ zoomed: !this.state.zoomed })
+    // }
+    const { clientX: x, clientY: y } = e
+    console.log(`App.js/onDblClick() x: ${x}, y: ${y}`)
+    this.setState({initialCenter: {x, y}})
   }
   render () {
-    const {selectedTab, zoomed} = this.state
+    const {selectedTab, zoomed, initialCenter} = this.state
     const selectedTabContent = tabs.find(({id}) => id === selectedTab)
     const initialScale = selectedTabContent.initialScale * (zoomed ? 1.5 : 1)
     return (
@@ -93,7 +97,7 @@ export default class App extends Component {
               {tabs.map((tab, i) => <TabButton key={i} {...tab} onClick={this.onChangeTab} className={selectedTabContent && tab.id === selectedTabContent.id ? 'is-active' : ''} />)}
             </ul>
           </div>
-          {selectedTabContent && this.renderTabContent({...selectedTabContent, initialScale})}
+          {selectedTabContent && this.renderTabContent({...selectedTabContent, initialScale, initialCenter})}
         </div>
       </div>
     )
@@ -109,7 +113,7 @@ export default class App extends Component {
       </div>
     )
   }
-  renderTabContent ({maxScale, containerRatio, image, initialScale, text, styles}) {
+  renderTabContent ({maxScale, containerRatio, image, initialScale, initialCenter, text, styles}) {
     if (!image) {
       return this.renderUsage()
     }
@@ -117,7 +121,7 @@ export default class App extends Component {
       <div className='content'>
         <p>{text}</p>
         <div className='pinch-wrapper'>
-          <PinchView debug backgroundColor='#ddd' maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
+          <PinchView debug backgroundColor='#ddd' initialCenter={initialCenter} maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
             <img src={image} style={styles} onDoubleClick={this.onDblClick} />
           </PinchView>
         </div>

--- a/demo/App.js
+++ b/demo/App.js
@@ -53,7 +53,7 @@ const tabs = [{
   image: imageHorizontal2,
   containerRatio: ((400 / 600) * 100),
   maxScale: 5,
-  initialScale: 2,
+  initialScale: 1,
   label: 'Double click',
   text: 'This allows you to zoom to a double-click location',
   styles: {
@@ -70,7 +70,7 @@ export default class App extends Component {
       // selectedTab: tabs[0].id,
       selectedTab: tabs[4].id,
       zoomed: false,
-      initialCenter: {x: 0, y: 50}
+      initialCenter: {x: 0, y: 0}
     }
   }
   onChangeTab = (selectedTab) => {

--- a/demo/App.js
+++ b/demo/App.js
@@ -53,8 +53,8 @@ const tabs = [{
   image: imageHorizontal2,
   containerRatio: ((400 / 600) * 100),
   maxScale: 5,
-  initialScale: 3,
-  label: 'Double-click',
+  initialScale: 2,
+  label: 'Double click',
   text: 'This allows you to zoom to a double-click location',
   styles: {
     margin: 'auto',
@@ -77,10 +77,10 @@ export default class App extends Component {
     this.setState({selectedTab})
   }
   onDblClick = (e) => {
-    // e.preventDefault()
-    // if (this.state.selectedTab === 'tab-3') {
-    //   this.setState({ zoomed: !this.state.zoomed })
-    // }
+    e.preventDefault()
+    if (this.state.selectedTab === 'tab-3') {
+      this.setState({ zoomed: !this.state.zoomed })
+    }
   }
   render () {
     const {selectedTab, zoomed, initialCenter} = this.state

--- a/demo/App.js
+++ b/demo/App.js
@@ -60,7 +60,8 @@ const tabs = [{
     margin: 'auto',
     width: '100%',
     height: 'auto'
-  }
+  },
+  zoomToDoubleClick: true
 }]
 
 export default class App extends Component {
@@ -121,7 +122,7 @@ export default class App extends Component {
       </div>
     )
   }
-  renderTabContent ({maxScale, containerRatio, image, initialScale, text, styles}) {
+  renderTabContent ({maxScale, containerRatio, image, initialScale, text, styles, zoomToDoubleClick}) {
     if (!image) {
       return this.renderUsage()
     }
@@ -129,7 +130,7 @@ export default class App extends Component {
       <div className='content'>
         <p>{text}</p>
         <div className='pinch-wrapper'>
-          <PinchView debug backgroundColor='#ddd' maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
+          <PinchView debug zoomToDoubleClick={zoomToDoubleClick} backgroundColor='#ddd' maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
             <img src={image} style={styles} onDoubleClick={this.onDblClick} />
           </PinchView>
         </div>

--- a/demo/App.js
+++ b/demo/App.js
@@ -128,7 +128,7 @@ export default class App extends Component {
     return (
       <div className='content'>
         <p>{text}</p>
-        <div className='pinch-wrapper' ref={ref => { this.div = ref }}>
+        <div className='pinch-wrapper'>
           <PinchView debug backgroundColor='#ddd' maxScale={maxScale} initialScale={initialScale} containerRatio={containerRatio} onPinchStart={() => console.log('pinch started')}>
             <img src={image} style={styles} onDoubleClick={this.onDblClick} />
           </PinchView>

--- a/demo/App.js
+++ b/demo/App.js
@@ -54,7 +54,8 @@ export default class App extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      selectedTab: tabs[0].id,
+      // selectedTab: tabs[0].id,
+      selectedTab: tabs[3].id,
       zoomed: false
     }
   }

--- a/src/PinchView.js
+++ b/src/PinchView.js
@@ -51,9 +51,9 @@ class PinchView extends Component {
   }
 
   render () {
-    const {debug, initialScale, maxScale, holderClassName, containerClassName, children, onPinchStart, onPinchStop} = this.props
+    const {debug, initialScale, initialCenter, maxScale, holderClassName, containerClassName, children, onPinchStart, onPinchStop} = this.props
     return (
-      <ReactPinchZoomPan initialScale={initialScale} maxScale={maxScale} render={(obj) => {
+      <ReactPinchZoomPan initialCenter={initialCenter} initialScale={initialScale} maxScale={maxScale} render={(obj) => {
         return (
           <div style={this.getHolderStyle()} className={holderClassName}>
             <div style={this.getContainerStyle()} className={containerClassName}>
@@ -82,6 +82,7 @@ PinchView.defaultProps = {
 PinchView.propTypes = {
   containerRatio: PropTypes.number,
   initialScale: PropTypes.number,
+  initialCenter: PropTypes.object,
   maxScale: PropTypes.number,
   children: PropTypes.element,
   containerClassName: PropTypes.string,

--- a/src/PinchView.js
+++ b/src/PinchView.js
@@ -51,9 +51,9 @@ class PinchView extends Component {
   }
 
   render () {
-    const {debug, initialScale, initialCenter, maxScale, holderClassName, containerClassName, children, onPinchStart, onPinchStop} = this.props
+    const {debug, initialScale, initialCenter, maxScale, holderClassName, containerClassName, children, onPinchStart, onPinchStop, zoomToDoubleClick} = this.props
     return (
-      <ReactPinchZoomPan initialCenter={initialCenter} initialScale={initialScale} maxScale={maxScale} render={(obj) => {
+      <ReactPinchZoomPan zoomToDoubleClick={zoomToDoubleClick} initialCenter={initialCenter} initialScale={initialScale} maxScale={maxScale} render={(obj) => {
         return (
           <div style={this.getHolderStyle()} className={holderClassName}>
             <div style={this.getContainerStyle()} className={containerClassName}>
@@ -76,7 +76,8 @@ PinchView.defaultProps = {
   maxScale: 2,
   containerRatio: 100,
   backgroundColor: '#f2f2f2',
-  debug: false
+  debug: false,
+  zoomToDoubleClick: false
 }
 
 PinchView.propTypes = {
@@ -90,7 +91,8 @@ PinchView.propTypes = {
   backgroundColor: PropTypes.string,
   debug: PropTypes.bool,
   onPinchStart: PropTypes.func,
-  onPinchStop: PropTypes.func
+  onPinchStop: PropTypes.func,
+  zoomToDoubleClick: PropTypes.bool
 }
 
 export default PinchView

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -230,18 +230,16 @@ class ReactPinchZoomPan extends Component {
       const {x, y} = initialCenter
       // zoom in and re-center
       this.setState({obj: {...obj, x, y, scale: this.props.maxScale}})
-      // console.log(bounds)
-      // console.log(divCenter)
-      // console.log(initialCenter)
     }
   }
 
   render () {
+    const { zoomToDoubleClick } = this.props
     const {scale, x, y} = this.state.obj
     return (
       <div
         ref={root => { this.root = root }}
-        onDoubleClick={e => this.onDoubleClick(e)}
+        onDoubleClick={zoomToDoubleClick ? e => this.onDoubleClick(e) : null}
       >
         {this.props.render({
           x: x.toFixed(2),
@@ -256,7 +254,8 @@ class ReactPinchZoomPan extends Component {
 ReactPinchZoomPan.defaultProps = {
   initialScale: 1,
   maxScale: 2,
-  initialCenter: {x: 0, y: 0}
+  initialCenter: {x: 0, y: 0},
+  zoomToDoubleClick: false
 }
 
 ReactPinchZoomPan.propTypes = {
@@ -265,7 +264,8 @@ ReactPinchZoomPan.propTypes = {
   onPinchStop: PropTypes.func,
   initialScale: PropTypes.number,
   initialCenter: PropTypes.object,
-  maxScale: PropTypes.number
+  maxScale: PropTypes.number,
+  zoomToDoubleClick: PropTypes.bool
 }
 
 export default ReactPinchZoomPan

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -85,6 +85,10 @@ class ReactPinchZoomPan extends Component {
     this.resize()
     this.resizeThrottled = throttle(() => this.resize(), 500)
     global.addEventListener('resize', this.resizeThrottled)
+
+    const {x, y} = this.props.initialCenter
+    const { obj } = this.state
+    this.setState({obj: {...obj, x, y}}, ()=>console.log(`saved state obj`))
   }
 
   componentWillReceiveProps (nextProps) {
@@ -209,7 +213,8 @@ class ReactPinchZoomPan extends Component {
 
 ReactPinchZoomPan.defaultProps = {
   initialScale: 1,
-  maxScale: 2
+  maxScale: 2,
+  initialCenter: {x: -100, y: 50}
 }
 
 ReactPinchZoomPan.propTypes = {
@@ -217,6 +222,7 @@ ReactPinchZoomPan.propTypes = {
   onPinchStart: PropTypes.func,
   onPinchStop: PropTypes.func,
   initialScale: PropTypes.number,
+  initialCenter: PropTypes.object,
   maxScale: PropTypes.number
 }
 

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -56,7 +56,8 @@ class ReactPinchZoomPan extends Component {
         y: 0
       },
       isPinching: false,
-      isPanning: false
+      isPanning: false,
+      zoomed: false
     }
     this.pinchTimeoutTimer = null
   }
@@ -204,27 +205,33 @@ class ReactPinchZoomPan extends Component {
     })
   }
 
+  // handle zoom to double-click coordinates
   onDoubleClick(e){
-    // handle zoom to double-click coordinates
-    const { clientX, clientY } = e
-    const bounds = this.root.getBoundingClientRect()
-    const { top, left, bottom, right, width, height } = bounds
-    // find the center of the image
-    const divCenter = { x: (right-left)/2 + left, y: (bottom-top)/2 + top,  }
-    // click offset is in image space (might have to flip)
-    const initialCenter = { x: divCenter.x - clientX, y: divCenter.y - clientY}
-    // limit offset to bounds
-    initialCenter.x = Math.abs(initialCenter.x) > width/4 ? (width/4)*Math.sign(initialCenter.x) : initialCenter.x
-    initialCenter.y = Math.abs(initialCenter.y) > height/4 ? (height/4)*Math.sign(initialCenter.y) : initialCenter.y
-    // save the new center to state
-    const {x, y} = initialCenter
+    // if zoomedin, just zoom out
     const { obj } = this.state
-
-    console.log(bounds)
-    console.log(divCenter)
-    console.log(initialCenter)
-
-    this.setState({obj: {...obj, x, y}})
+    const {scale} = obj
+    if(isZoomed(scale)){
+      // reset the zoom and center on the obj
+      this.setState({obj: {...obj, scale: 1, x: 0, y: 0}})
+    }else{
+      // not zoomed in yet, do the zoom now
+      const { clientX, clientY } = e
+      const bounds = this.root.getBoundingClientRect()
+      const { top, left, bottom, right, width, height } = bounds
+      // find the center of the image
+      const divCenter = { x: (right-left)/2 + left, y: (bottom-top)/2 + top,  }
+      // click offset is in image space (might have to flip)
+      const initialCenter = { x: divCenter.x - clientX, y: divCenter.y - clientY}
+      // limit offset to bounds
+      initialCenter.x = Math.abs(initialCenter.x) > width/4 ? (width/4)*Math.sign(initialCenter.x) : initialCenter.x
+      initialCenter.y = Math.abs(initialCenter.y) > height/4 ? (height/4)*Math.sign(initialCenter.y) : initialCenter.y
+      // save the new center to state
+      const {x, y} = initialCenter
+      this.setState({obj: {...obj, x, y}})
+      // console.log(bounds)
+      // console.log(divCenter)
+      // console.log(initialCenter)
+    }
   }
 
   render () {

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -86,14 +86,21 @@ class ReactPinchZoomPan extends Component {
     this.resizeThrottled = throttle(() => this.resize(), 500)
     global.addEventListener('resize', this.resizeThrottled)
 
+    // save initial center to state
     const {x, y} = this.props.initialCenter
     const { obj } = this.state
-    this.setState({obj: {...obj, x, y}}, ()=>console.log(`saved state obj`))
+    this.setState({obj: {...obj, x, y}})
   }
 
   componentWillReceiveProps (nextProps) {
+    // update when parent changes scale
     if (this.state.obj.scale !== nextProps.initialScale) {
       const obj = {...this.state.obj, scale: nextProps.initialScale}
+      this.setState({ obj })
+    }
+    // update when parent changes center coordinates
+    if (this.state.obj.x !== nextProps.initialCenter.x || this.state.obj.y !== nextProps.initialCenter.y) {
+      const obj = {...this.state.obj, x: nextProps.initialCenter.x, y: nextProps.initialCenter.y}
       this.setState({ obj })
     }
   }

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -207,16 +207,18 @@ class ReactPinchZoomPan extends Component {
 
   // handle zoom to double-click coordinates
   onDoubleClick(e){
-    // if zoomedin, just zoom out
     const { obj } = this.state
     const {scale} = obj
+    // zoom out or zoom in
     if(isZoomed(scale)){
       // reset the zoom and center on the obj
       this.setState({obj: {...obj, scale: 1, x: 0, y: 0}})
     }else{
-      // not zoomed in yet, do the zoom now
+      // read event coordinates
       const { clientX, clientY } = e
+      // get the bounding box for the content
       const bounds = this.root.getBoundingClientRect()
+      // unpack the bounding box
       const { top, left, bottom, right, width, height } = bounds
       // find the center of the image
       const divCenter = { x: (right-left)/2 + left, y: (bottom-top)/2 + top,  }
@@ -227,7 +229,8 @@ class ReactPinchZoomPan extends Component {
       initialCenter.y = Math.abs(initialCenter.y) > height/4 ? (height/4)*Math.sign(initialCenter.y) : initialCenter.y
       // save the new center to state
       const {x, y} = initialCenter
-      this.setState({obj: {...obj, x, y}})
+      // zoom in and re-center
+      this.setState({obj: {...obj, x, y, scale: this.props.maxScale}})
       // console.log(bounds)
       // console.log(divCenter)
       // console.log(initialCenter)

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -56,8 +56,7 @@ class ReactPinchZoomPan extends Component {
         y: 0
       },
       isPinching: false,
-      isPanning: false,
-      zoomed: false
+      isPanning: false
     }
     this.pinchTimeoutTimer = null
   }

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -208,7 +208,6 @@ class ReactPinchZoomPan extends Component {
     // handle zoom to double-click coordinates
     const { clientX, clientY } = e
     const bounds = this.root.getBoundingClientRect()
-    console.log('hi')
     const { top, left, bottom, right, width, height } = bounds
     // find the center of the image
     const divCenter = { x: (right-left)/2 + left, y: (bottom-top)/2 + top,  }

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -206,14 +206,14 @@ class ReactPinchZoomPan extends Component {
   }
 
   // handle zoom to double-click coordinates
-  onDoubleClick(e){
+  onDoubleClick (e) {
     const { obj } = this.state
     const {scale} = obj
     // zoom out or zoom in
-    if(isZoomed(scale)){
+    if (isZoomed(scale)) {
       // reset the zoom and center on the obj
       this.setState({obj: {...obj, scale: 1, x: 0, y: 0}})
-    }else{
+    } else {
       // read event coordinates
       const { clientX, clientY } = e
       // get the bounding box for the content
@@ -221,12 +221,12 @@ class ReactPinchZoomPan extends Component {
       // unpack the bounding box
       const { top, left, bottom, right, width, height } = bounds
       // find the center of the image
-      const divCenter = { x: (right-left)/2 + left, y: (bottom-top)/2 + top,  }
+      const divCenter = { x: (right - left) / 2 + left, y: (bottom - top) / 2 + top }
       // click offset is in image space (might have to flip)
-      const initialCenter = { x: divCenter.x - clientX, y: divCenter.y - clientY}
+      const initialCenter = {x: divCenter.x - clientX, y: divCenter.y - clientY}
       // limit offset to bounds
-      initialCenter.x = Math.abs(initialCenter.x) > width/4 ? (width/4)*Math.sign(initialCenter.x) : initialCenter.x
-      initialCenter.y = Math.abs(initialCenter.y) > height/4 ? (height/4)*Math.sign(initialCenter.y) : initialCenter.y
+      initialCenter.x = Math.abs(initialCenter.x) > width / 4 ? (width / 4) * Math.sign(initialCenter.x) : initialCenter.x
+      initialCenter.y = Math.abs(initialCenter.y) > height / 4 ? (height / 4) * Math.sign(initialCenter.y) : initialCenter.y
       // save the new center to state
       const {x, y} = initialCenter
       // zoom in and re-center
@@ -240,9 +240,9 @@ class ReactPinchZoomPan extends Component {
   render () {
     const {scale, x, y} = this.state.obj
     return (
-      <div 
+      <div
         ref={root => { this.root = root }}
-        onDoubleClick={this.onDoubleClick.bind(this)}
+        onDoubleClick={e => this.onDoubleClick(e)}
       >
         {this.props.render({
           x: x.toFixed(2),

--- a/src/ReactPinchZoomPan.js
+++ b/src/ReactPinchZoomPan.js
@@ -204,10 +204,37 @@ class ReactPinchZoomPan extends Component {
     })
   }
 
+  onDoubleClick(e){
+    // handle zoom to double-click coordinates
+    const { clientX, clientY } = e
+    const bounds = this.root.getBoundingClientRect()
+    console.log('hi')
+    const { top, left, bottom, right, width, height } = bounds
+    // find the center of the image
+    const divCenter = { x: (right-left)/2 + left, y: (bottom-top)/2 + top,  }
+    // click offset is in image space (might have to flip)
+    const initialCenter = { x: divCenter.x - clientX, y: divCenter.y - clientY}
+    // limit offset to bounds
+    initialCenter.x = Math.abs(initialCenter.x) > width/4 ? (width/4)*Math.sign(initialCenter.x) : initialCenter.x
+    initialCenter.y = Math.abs(initialCenter.y) > height/4 ? (height/4)*Math.sign(initialCenter.y) : initialCenter.y
+    // save the new center to state
+    const {x, y} = initialCenter
+    const { obj } = this.state
+
+    console.log(bounds)
+    console.log(divCenter)
+    console.log(initialCenter)
+
+    this.setState({obj: {...obj, x, y}})
+  }
+
   render () {
     const {scale, x, y} = this.state.obj
     return (
-      <div ref={root => { this.root = root }}>
+      <div 
+        ref={root => { this.root = root }}
+        onDoubleClick={this.onDoubleClick.bind(this)}
+      >
         {this.props.render({
           x: x.toFixed(2),
           y: y.toFixed(2),
@@ -221,7 +248,7 @@ class ReactPinchZoomPan extends Component {
 ReactPinchZoomPan.defaultProps = {
   initialScale: 1,
   maxScale: 2,
-  initialCenter: {x: -100, y: 50}
+  initialCenter: {x: 0, y: 0}
 }
 
 ReactPinchZoomPan.propTypes = {


### PR DESCRIPTION
- Added prop ```initialCenter``` to specify initial pan offset.
- Added an event handler for double-clicks. It will zoom in on the clicked location in the image.
- Added a prop ```zoomToDoubleClick``` to enable/disable double-click zooming.
- Added a 5th tab to the demo app to show how this works.